### PR TITLE
Fix Swift 6 Concurrency Warnings in ViewModels

### DIFF
--- a/Shared/ViewModels/EventsViewModel.swift
+++ b/Shared/ViewModels/EventsViewModel.swift
@@ -26,7 +26,7 @@ class EventsViewModel: BaseViewModelProtocol {
     private let eventsManager: EventsManager
     private var loadTask: Task<Void, Never>?
     
-    init(eventsManager: EventsManager = EventsManager.shared) {
+    nonisolated init(eventsManager: EventsManager = MainActor.assumeIsolated { EventsManager.shared }) {
         self.eventsManager = eventsManager
     }
     

--- a/Shared/ViewModels/ResourcesViewModel.swift
+++ b/Shared/ViewModels/ResourcesViewModel.swift
@@ -27,7 +27,7 @@ class ResourcesViewModel: BaseViewModelProtocol {
     private let resourcesManager: ResourcesManager
     private var loadTask: Task<Void, Never>?
     
-    init(resourcesManager: ResourcesManager = ResourcesManager.shared) {
+    nonisolated init(resourcesManager: ResourcesManager = MainActor.assumeIsolated { ResourcesManager.shared }) {
         self.resourcesManager = resourcesManager
     }
     

--- a/Shared/ViewModels/SearchViewModel.swift
+++ b/Shared/ViewModels/SearchViewModel.swift
@@ -32,9 +32,9 @@ class SearchViewModel {
     private var allArticles: [NewsArticle] = []
     private var isDataLoaded = false
 
-    init(
-        resourcesManager: ResourcesManager = .shared,
-        eventsManager: EventsManager = .shared
+    nonisolated init(
+        resourcesManager: ResourcesManager = MainActor.assumeIsolated { ResourcesManager.shared },
+        eventsManager: EventsManager = MainActor.assumeIsolated { EventsManager.shared }
     ) {
         self.resourcesManager = resourcesManager
         self.eventsManager = eventsManager


### PR DESCRIPTION
## Description

Fixes Swift 6 concurrency warnings about main actor isolation in ViewModels.

## Changes

- Marked ViewModel initializers as `nonisolated`
- Used `MainActor.assumeIsolated` when accessing shared manager instances in default parameters
- Affected files:
  - `Shared/ViewModels/EventsViewModel.swift`
  - `Shared/ViewModels/ResourcesViewModel.swift`
  - `Shared/ViewModels/SearchViewModel.swift`

## Testing

- [x] Build succeeds without warnings
- [x] No runtime errors
- [x] ViewModels still function correctly

## Related

Closes #2