### PR TITLE
Add Missing AccentColor Asset

### DIFF
--- a/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Description

Adds the missing AccentColor asset to Assets.xcassets to fix the build warning.

## Changes

- Created `AccentColor.colorset` in `Resources/Assets.xcassets/`
- Added universal color set configuration

## Testing

- [x] Build warning resolved
- [x] Asset catalog validates correctly

## Related

Closes #3