### PR TITLE
Fix macOS Target Platform Configuration

### DIFF
--- a/DisabilityAdvocacy.xcodeproj/project.pbxproj
+++ b/DisabilityAdvocacy.xcodeproj/project.pbxproj
@@ -1429,6 +1429,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.disabilityadvocacy.macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1453,6 +1455,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.disabilityadvocacy.macos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Description

Fixes the macOS target platform configuration warning by explicitly setting SUPPORTED_PLATFORMS and SDKROOT.

## Changes

- Added `SUPPORTED_PLATFORMS = macosx;` to Debug configuration
- Added `SUPPORTED_PLATFORMS = macosx;` to Release configuration
- Added `SDKROOT = macosx;` to both configurations

## Testing

- [x] Build warning resolved
- [x] macOS target builds successfully
- [x] No platform selection warnings

## Related

Closes #4