### PR TITLE
[v0.2.0] Enhance Resources Features (#17, #18, #19)

### DIFF
--- a/Shared/Models/Core/Resource.swift
+++ b/Shared/Models/Core/Resource.swift
@@ -53,8 +53,8 @@ enum ResourceCategory: String, Codable, CaseIterable {
 
 // MARK: - Resource Filtering Extension
 extension Array where Element == Resource {
-    /// Filters resources by search text and category
-    func filtered(searchText: String, category: ResourceCategory?) -> [Resource] {
+    /// Filters resources by search text, category, and tag
+    func filtered(searchText: String, category: ResourceCategory?, tag: String?) -> [Resource] {
         var filtered = self
 
         // Pre-compute lowercase search for efficiency
@@ -66,6 +66,10 @@ extension Array where Element == Resource {
 
         if let category = category {
             filtered = filtered.filter { $0.category == category }
+        }
+        
+        if let tag = tag {
+            filtered = filtered.filter { $0.tags.contains(tag) }
         }
 
         return filtered

--- a/Shared/ViewModels/ResourcesViewModel.swift
+++ b/Shared/ViewModels/ResourcesViewModel.swift
@@ -19,9 +19,15 @@ class ResourcesViewModel: BaseViewModelProtocol {
     // Filtering
     var searchText: String = ""
     var selectedCategory: ResourceCategory?
+    var selectedTag: String?
     
     var filteredResources: [Resource] {
-        resources.filtered(searchText: searchText, category: selectedCategory)
+        resources.filtered(searchText: searchText, category: selectedCategory, tag: selectedTag)
+    }
+    
+    var availableTags: [String] {
+        let allTags = resources.flatMap { $0.tags }
+        return Array(Set(allTags)).sorted()
     }
     
     private let resourcesManager: ResourcesManager
@@ -34,6 +40,7 @@ class ResourcesViewModel: BaseViewModelProtocol {
     func clearFilters() {
         searchText = ""
         selectedCategory = nil
+        selectedTag = nil
     }
     
     func loadResources() {

--- a/Shared/Views/Main/ResourcesView.swift
+++ b/Shared/Views/Main/ResourcesView.swift
@@ -82,8 +82,8 @@ struct ResourcesContentView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var emptyStateMessage: String {
-        if viewModel.selectedCategory != nil {
-            return String(localized: "Try selecting a different category or clearing the filter.")
+        if viewModel.selectedCategory != nil || viewModel.selectedTag != nil {
+            return String(localized: "Try selecting a different category or tag, or clearing the filters.")
         } else if !viewModel.searchText.isEmpty {
             return String(localized: "Try adjusting your search terms.")
         } else {
@@ -93,13 +93,25 @@ struct ResourcesContentView: View {
 
     // MARK: - Filter Buttons
     private var filterButtonRow: some View {
-        Picker(String(localized: "Category"), selection: $viewModel.selectedCategory) {
-            Text(String(localized: "All Categories")).tag(Optional<ResourceCategory>.none)
-            ForEach(ResourceCategory.allCases, id: \.self) { category in
-                Text(category.rawValue).tag(Optional(category))
+        VStack(spacing: LayoutConstants.spacingS) {
+            Picker(String(localized: "Category"), selection: $viewModel.selectedCategory) {
+                Text(String(localized: "All Categories")).tag(Optional<ResourceCategory>.none)
+                ForEach(ResourceCategory.allCases, id: \.self) { category in
+                    Text(category.rawValue).tag(Optional(category))
+                }
+            }
+            .pickerStyle(.menu)
+            
+            if !viewModel.availableTags.isEmpty {
+                Picker(String(localized: "Tag"), selection: $viewModel.selectedTag) {
+                    Text(String(localized: "All Tags")).tag(Optional<String>.none)
+                    ForEach(viewModel.availableTags, id: \.self) { tag in
+                        Text(tag).tag(Optional(tag))
+                    }
+                }
+                .pickerStyle(.menu)
             }
         }
-        .pickerStyle(.menu)
         .padding(.horizontal, LayoutConstants.screenHorizontalPadding)
     }
     
@@ -179,7 +191,7 @@ struct ResourcesContentView: View {
             icon: "magnifyingglass",
             title: String(localized: "No resources found"),
             message: emptyStateMessage,
-            primaryActionTitle: (viewModel.selectedCategory != nil || !viewModel.searchText.isEmpty) ? String(localized: "Clear all filters") : nil,
+            primaryActionTitle: (viewModel.selectedCategory != nil || viewModel.selectedTag != nil || !viewModel.searchText.isEmpty) ? String(localized: "Clear all filters") : nil,
             primaryAction: { viewModel.clearFilters() }
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
# Add Tag Filtering to Resources View

## Summary

Adds tag-based filtering capability to the Resources view, allowing users to filter resources by tags in addition to category and search text.

## What Changed

### Files Modified

1. **`Shared/Models/Core/Resource.swift`**
   - Updated `filtered()` method to accept optional `tag` parameter
   - Added tag filtering logic: `filtered.filter { $0.tags.contains(tag) }`

2. **`Shared/ViewModels/ResourcesViewModel.swift`**
   - Added `selectedTag: String?` property for tag selection
   - Added `availableTags` computed property that extracts unique tags from all resources
   - Updated `filteredResources` to include tag filtering
   - Updated `clearFilters()` to reset tag selection

3. **`Shared/Views/Main/ResourcesView.swift`**
   - Added tag picker UI below category picker
   - Updated empty state message to mention tags
   - Updated clear filters button to include tag state

## User-Facing Changes

**Before:** Users could only filter by:
- Search text
- Category

**After:** Users can now filter by:
- Search text
- Category
- **Tag** (new)

## UI Changes

- Tag picker appears below category picker when tags are available
- Empty state messages now mention tags
- "Clear all filters" button clears tags along with other filters

## Code Changes Breakdown

```swift
// Model: Added tag parameter to filtering
func filtered(searchText: String, category: ResourceCategory?, tag: String?) -> [Resource]

// ViewModel: Added tag selection state
var selectedTag: String?
var availableTags: [String] { /* extracts unique tags */ }

// View: Added tag picker UI
Picker("Tag", selection: $viewModel.selectedTag) { ... }
```

## Testing

- [x] Tag picker appears when resources have tags
- [x] Tag filtering works correctly
- [x] Category + tag filtering works together
- [x] Search + category + tag filtering works together
- [x] Clear filters resets tag selection
- [x] Empty state shows when no resources match tag filter

## Related Issues

Closes #17 - Resources List View (enhanced with tag filtering)
Closes #18 - Resources Search and Filter (tag filtering added)
Closes #19 - Resource Details View (no changes needed, already complete)