### PR TITLE
Fix Swift 6 concurrency errors (Issue #32)

### DIFF
--- a/Shared/Views/Admin/DataExportView.swift
+++ b/Shared/Views/Admin/DataExportView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct DataExportView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -28,6 +29,7 @@ struct DataExportView: View {
         )
     }
     
+    @MainActor
     private func exportButton(filename: String, icon: String, color: Color) -> some View {
         let fileURL = DataManager.shared.getJSONStorageManager().getLocalFileURL(for: filename)
         

--- a/Shared/Views/Admin/EventManagementViews.swift
+++ b/Shared/Views/Admin/EventManagementViews.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct ManageEventsView: View {
     @State private var events: [Event] = []
     @State private var showingEditView = false
@@ -71,10 +72,12 @@ struct ManageEventsView: View {
         .onAppear(perform: loadEvents)
     }
     
+    @MainActor
     private func loadEvents() {
         events = EventsManager.shared.getAllEvents()
     }
     
+    @MainActor
     private func deleteEvents(at offsets: IndexSet) {
         for index in offsets {
             EventsManager.shared.deleteEvent(id: events[index].id)

--- a/Shared/Views/Admin/ResourceManagementViews.swift
+++ b/Shared/Views/Admin/ResourceManagementViews.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct ManageResourcesView: View {
     @State private var resources: [Resource] = []
     @State private var showingEditView = false
@@ -67,10 +68,12 @@ struct ManageResourcesView: View {
         .onAppear(perform: loadResources)
     }
     
+    @MainActor
     private func loadResources() {
         resources = ResourcesManager.shared.getAllResources()
     }
     
+    @MainActor
     private func deleteResources(at offsets: IndexSet) {
         for index in offsets {
             ResourcesManager.shared.deleteResource(id: resources[index].id)

--- a/Shared/Views/Main/CommunityView.swift
+++ b/Shared/Views/Main/CommunityView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct CommunityView: View {
     @Environment(AppState.self) var appState
     @State private var viewModel = CommunityViewModel()

--- a/Shared/Views/Main/CreatePostView.swift
+++ b/Shared/Views/Main/CreatePostView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct CreatePostView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(AppState.self) var appState

--- a/Shared/Views/Main/LetterTemplateView.swift
+++ b/Shared/Views/Main/LetterTemplateView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct LetterTemplateView: View {
     @State private var viewModel = LetterTemplateViewModel()
     @State private var selectedCategory: LetterCategory?

--- a/Shared/Views/Main/NewsView.swift
+++ b/Shared/Views/Main/NewsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct NewsView: View {
     @Environment(AppState.self) var appState
     @State private var viewModel = NewsViewModel()

--- a/Shared/Views/Search/SearchView.swift
+++ b/Shared/Views/Search/SearchView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct SearchView: View {
     @State private var viewModel = SearchViewModel()
     @Environment(AppState.self) var appState: AppState
@@ -331,11 +332,13 @@ struct SearchView: View {
     }
     
     // Helper methods to find items (simplified - should use ViewModels in production)
+    @MainActor
     private func findResource(id: UUID) -> Resource? {
         let resources = ResourcesManager.shared.getAllResources()
         return resources.first { $0.id == id }
     }
     
+    @MainActor
     private func findEvent(id: UUID) -> Event? {
         let events = EventsManager.shared.getAllEvents()
         return events.first { $0.id == id }

--- a/iOS/AdvocacyApp.swift
+++ b/iOS/AdvocacyApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import SwiftData
 
 @main
+@MainActor
 struct AdvocacyApp: App {
     @State private var appState = AppState()
     @State private var notificationManager = NotificationManager.shared

--- a/iOS/Views/HomeView.swift
+++ b/iOS/Views/HomeView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct HomeView: View {
     @Environment(AppState.self) var appState
     @State private var viewModel = HomeViewModel()

--- a/macOS/AdvocacyApp.swift
+++ b/macOS/AdvocacyApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import SwiftData
 
 @main
+@MainActor
 struct AdvocacyApp: App {
     @State private var appState = AppState()
     @State private var notificationManager = NotificationManager.shared

--- a/macOS/Views/HomeView.swift
+++ b/macOS/Views/HomeView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@MainActor
 struct HomeView: View {
     @Environment(AppState.self) var appState
     @State private var viewModel = HomeViewModel()


### PR DESCRIPTION
- Add @MainActor to SearchView and fix binding isolation
- Add @MainActor to Admin views (EventManagementViews, ResourceManagementViews, DataExportView)
- Add @MainActor to View initializers (HomeView, AdvocacyApp, CommunityView, NewsView, LetterTemplateView, CreatePostView)
- Fix helper methods in SearchView to be MainActor-isolated

Fixes:
- #49: SearchView.swift concurrency errors
- #50: Admin views concurrency errors
- #51: View initializer concurrency errors

Part of #32: Complete Swift 6 Concurrency Migration