### PR TITLE
feat: integrate macOS file operations (#26)

### DIFF
--- a/Shared/Models/UI/AppState.swift
+++ b/Shared/Models/UI/AppState.swift
@@ -24,6 +24,9 @@ class AppState {
     var showSearch = false
     var showKeyboardShortcuts = false
     
+    // File operations
+    private let fileOperationsManager = FileOperationsManager.shared
+    
     static private let favoritesKey = "favoriteResourceIds"
     
     static private func loadFavorites() -> Set<UUID> {
@@ -51,5 +54,73 @@ class AppState {
             feedback.success(String(localized: "Added to favorites"))
         }
         persistFavorites()
+    }
+    
+    // MARK: - File Operations
+    
+    /// Import resources from a JSON file
+    func importResources() async {
+        guard let importedResources = await fileOperationsManager.importResources() else {
+            feedback.error(String(localized: "Failed to import resources. Please check the file format."))
+            return
+        }
+        
+        // Add imported resources to ResourcesManager
+        for resource in importedResources {
+            ResourcesManager.shared.addResource(resource)
+        }
+        
+        feedback.success(String(localized: "Successfully imported \(importedResources.count) resource(s)."))
+    }
+    
+    /// Import events from a JSON file
+    func importEvents() async {
+        guard let importedEvents = await fileOperationsManager.importEvents() else {
+            feedback.error(String(localized: "Failed to import events. Please check the file format."))
+            return
+        }
+        
+        // Add imported events to EventsManager
+        for event in importedEvents {
+            EventsManager.shared.addEvent(event)
+        }
+        
+        feedback.success(String(localized: "Successfully imported \(importedEvents.count) event(s)."))
+    }
+    
+    /// Export resources to a JSON file
+    func exportResources() async {
+        let allResources = ResourcesManager.shared.getAllResources()
+        
+        guard !allResources.isEmpty else {
+            feedback.warning(String(localized: "No resources to export."))
+            return
+        }
+        
+        let success = await fileOperationsManager.exportResources(allResources)
+        
+        if success {
+            feedback.success(String(localized: "Successfully exported \(allResources.count) resource(s)."))
+        } else {
+            feedback.error(String(localized: "Failed to export resources."))
+        }
+    }
+    
+    /// Export events to a JSON file
+    func exportEvents() async {
+        let allEvents = EventsManager.shared.getAllEvents()
+        
+        guard !allEvents.isEmpty else {
+            feedback.warning(String(localized: "No events to export."))
+            return
+        }
+        
+        let success = await fileOperationsManager.exportEvents(allEvents)
+        
+        if success {
+            feedback.success(String(localized: "Successfully exported \(allEvents.count) event(s)."))
+        } else {
+            feedback.error(String(localized: "Failed to export events."))
+        }
     }
 }

--- a/Shared/Views/Admin/DataExportView.swift
+++ b/Shared/Views/Admin/DataExportView.swift
@@ -2,22 +2,81 @@
 //  DataExportView.swift
 //  Disability Advocacy
 //
-//  View for exporting local data changes.
+//  View for importing and exporting data files.
 //
 
 import SwiftUI
 
 @MainActor
 struct DataExportView: View {
+    @Environment(AppState.self) private var appState
+    
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(String(localized: "Export local data files to use as bundled resources in the project."))
+        VStack(alignment: .leading, spacing: 20) {
+            Text(String(localized: "Import and export data files for backup or sharing."))
                 .font(.subheadline)
                 .foregroundStyle(Color.secondaryText)
             
-            HStack(spacing: 12) {
-                exportButton(filename: "Resources.json", icon: "book.fill", color: .triadPrimary)
-                exportButton(filename: "Events.json", icon: "calendar", color: .triadSecondary)
+            #if os(macOS)
+            // Import Section
+            VStack(alignment: .leading, spacing: 12) {
+                Text(String(localized: "Import"))
+                    .font(.headline)
+                    .foregroundStyle(Color.primaryText)
+                
+                HStack(spacing: 12) {
+                    importButton(
+                        title: String(localized: "Import Resources"),
+                        icon: "square.and.arrow.down.fill",
+                        color: .triadPrimary
+                    ) {
+                        Task {
+                            await appState.importResources()
+                        }
+                    }
+                    
+                    importButton(
+                        title: String(localized: "Import Events"),
+                        icon: "square.and.arrow.down.fill",
+                        color: .triadSecondary
+                    ) {
+                        Task {
+                            await appState.importEvents()
+                        }
+                    }
+                }
+            }
+            
+            Divider()
+            #endif
+            
+            // Export Section
+            VStack(alignment: .leading, spacing: 12) {
+                Text(String(localized: "Export"))
+                    .font(.headline)
+                    .foregroundStyle(Color.primaryText)
+                
+                HStack(spacing: 12) {
+                    exportButton(
+                        title: String(localized: "Export Resources"),
+                        icon: "square.and.arrow.up.fill",
+                        color: .triadPrimary
+                    ) {
+                        Task {
+                            await appState.exportResources()
+                        }
+                    }
+                    
+                    exportButton(
+                        title: String(localized: "Export Events"),
+                        icon: "square.and.arrow.up.fill",
+                        color: .triadSecondary
+                    ) {
+                        Task {
+                            await appState.exportEvents()
+                        }
+                    }
+                }
             }
         }
         .padding(LayoutConstants.cardPadding)
@@ -29,38 +88,41 @@ struct DataExportView: View {
         )
     }
     
+    #if os(macOS)
     @MainActor
-    private func exportButton(filename: String, icon: String, color: Color) -> some View {
-        let fileURL = DataManager.shared.getJSONStorageManager().getLocalFileURL(for: filename)
-        
-        return Group {
-            if let url = fileURL {
-                ShareLink(item: url) {
-                    HStack(spacing: 8) {
-                        Image(systemName: icon)
-                        Text(filename)
-                            .font(.subheadline.weight(.semibold))
-                    }
-                    .padding(.vertical, 12)
-                    .padding(.horizontal, 16)
-                    .frame(maxWidth: .infinity)
-                    .background(color.opacity(0.1))
-                    .foregroundStyle(color)
-                    .cornerRadius(10)
-                }
-            } else {
-                HStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.triangle")
-                    Text(filename)
-                        .font(.subheadline)
-                }
-                .padding(.vertical, 12)
-                .padding(.horizontal, 16)
-                .frame(maxWidth: .infinity)
-                .background(Color.secondary.opacity(0.1))
-                .foregroundStyle(.secondary)
-                .cornerRadius(10)
+    private func importButton(title: String, icon: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
             }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity)
+            .background(color.opacity(0.1))
+            .foregroundStyle(color)
+            .cornerRadius(10)
         }
+        .buttonStyle(.plain)
+    }
+    #endif
+    
+    @MainActor
+    private func exportButton(title: String, icon: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity)
+            .background(color.opacity(0.1))
+            .foregroundStyle(color)
+            .cornerRadius(10)
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/macOS/AdvocacyApp.swift
+++ b/macOS/AdvocacyApp.swift
@@ -50,29 +50,27 @@ struct AppCommands: Commands {
         CommandGroup(replacing: .newItem) {}
         
         CommandGroup(after: .newItem) {
-            // Note: Import resources functionality can be added to AppState if needed
-            // Button("Import Resources...") {
-            //     Task { await appState.importResources() }
-            // }
-            // .keyboardShortcut("i", modifiers: [.command, .shift])
+            Button("Import Resources...") {
+                Task { await appState.importResources() }
+            }
+            .keyboardShortcut("i", modifiers: [.command, .shift])
             
-            // Note: Import/Export functionality can be added to AppState if needed
-            // Button("Import Events...") {
-            //     Task { await appState.importEvents() }
-            // }
-            // .keyboardShortcut("i", modifiers: [.command, .option])
+            Button("Import Events...") {
+                Task { await appState.importEvents() }
+            }
+            .keyboardShortcut("i", modifiers: [.command, .option])
             
-            // Divider()
+            Divider()
             
-            // Button("Export Resources...") {
-            //     Task { await appState.exportResources() }
-            // }
-            // .keyboardShortcut("e", modifiers: [.command, .shift])
+            Button("Export Resources...") {
+                Task { await appState.exportResources() }
+            }
+            .keyboardShortcut("e", modifiers: [.command, .shift])
             
-            // Button("Export Events...") {
-            //     Task { await appState.exportEvents() }
-            // }
-            // .keyboardShortcut("e", modifiers: [.command, .option])
+            Button("Export Events...") {
+                Task { await appState.exportEvents() }
+            }
+            .keyboardShortcut("e", modifiers: [.command, .option])
         }
         
         CommandGroup(replacing: .textEditing) {


### PR DESCRIPTION
## Description

This PR completes the integration of macOS file operations (import/export) as specified in issue #26.

## Changes

### AppState Integration
- Added `importResources()`, `importEvents()`, `exportResources()`, and `exportEvents()` methods to `AppState`
- Methods use `FileOperationsManager` to handle file operations
- Provides user feedback via toast notifications

### Menu Commands
- Uncommented and wired up import/export menu commands in `macOS/AdvocacyApp.swift`
- Keyboard shortcuts:
  - ⌘⇧I - Import Resources
  - ⌘⌥I - Import Events
  - ⌘⇧E - Export Resources
  - ⌘⌥E - Export Events

### UI Updates
- Updated `DataExportView` to use `FileOperationsManager` instead of `ShareLink`
- Added import buttons to admin dashboard (macOS only)
- Improved UI with better labels and organization

## Requirements Met

✅ Import resources from JSON files  
✅ Import events from JSON files  
✅ Export resources to JSON  
✅ Export events to JSON  
✅ Use NSOpenPanel for file selection  
✅ Use NSSavePanel for file saving  
✅ Error handling for file operations  

## Testing

- [ ] Test import resources from JSON file
- [ ] Test import events from JSON file
- [ ] Test export resources to JSON file
- [ ] Test export events to JSON file
- [ ] Verify menu commands work correctly
- [ ] Verify keyboard shortcuts work
- [ ] Test error handling (invalid files, cancelled dialogs)
- [ ] Verify user feedback (toast notifications)

## Related

Fixes #26